### PR TITLE
Send product's image's delete call if the product has no file when calling sync

### DIFF
--- a/classes/SRBProduct.php
+++ b/classes/SRBProduct.php
@@ -7,6 +7,7 @@ class SRBProduct extends LibProduct implements PSElementInterface
 {
     use PSElementTrait {
         getBaseQuery as protected trait_getBaseQuery;
+        sync as protected trait_sync;
     }
 
     public function __construct($psProduct)
@@ -247,5 +248,18 @@ class SRBProduct extends LibProduct implements PSElementInterface
             'pac.id_attribute = al.id_attribute AND
             al.id_lang = ' . Configuration::get('PS_LANG_DEFAULT')
         );
+    }
+
+    public function sync()
+    {
+        if (!isset($this->picture_file_url) && !isset($this->picture_file_base64)) {
+            try {
+                $this->deleteImage();
+            } catch (Exception $e) {
+                SRBLogger::addLog('Error when deleting product\'s image: ' . json_encode($e), SRBLogger::FATAL, SRBProduct::getObjectTypeForMapping(), $this->getDBId());
+            }
+        }
+
+        return $this->trait_sync();
     }
 }

--- a/shoprunback.php
+++ b/shoprunback.php
@@ -56,7 +56,7 @@ class ShopRunBack extends Module
         // Mandatory parameters
         $this->name = 'shoprunback';
         $this->author = 'ShopRunBack';
-        $this->version = '1.0.14';
+        $this->version = '1.0.15';
         $this->ps_versions_compliancy = array('min' => '1.6.0.9');
         $this->tab = 'administration';
         $this->tabs = [


### PR DESCRIPTION
tested on local and sandbox, both 1.6.0.9 and 1.7.2
-----
fixes #128 (automatic)